### PR TITLE
Xml backslash path fixes

### DIFF
--- a/kieker-trace-diagnosis-release-engineering/assembly/bin-base.xml
+++ b/kieker-trace-diagnosis-release-engineering/assembly/bin-base.xml
@@ -4,7 +4,7 @@
 
 	<fileSets>
 		<fileSet>
-			<directory>${project.build.directory}\appassembler\lib</directory>
+			<directory>${project.build.directory}/appassembleri/lib</directory>
 			<outputDirectory>lib</outputDirectory>
 		</fileSet>
 
@@ -14,7 +14,7 @@
 		</fileSet>
 
 		<fileSet>
-			<directory>..\kieker-trace-diagnosis-application\src\main\resources\kieker\diagnosis\ui\manual\html</directory>
+			<directory>../kieker-trace-diagnosis-application/src/main/resources/kieker/diagnosis/ui/manual/html</directory>
 			<outputDirectory>manual</outputDirectory>
 			<filtered>true</filtered>
 			<includes>
@@ -25,10 +25,10 @@
 
 	<files>
 		<file>
-			<source>..\CHANGELOG</source>
+			<source>../CHANGELOG</source>
 		</file>
 		<file>
-			<source>..\LICENSE</source>
+			<source>../LICENSE</source>
 		</file>
 	</files>
 

--- a/kieker-trace-diagnosis-release-engineering/assembly/bin-base.xml
+++ b/kieker-trace-diagnosis-release-engineering/assembly/bin-base.xml
@@ -4,7 +4,7 @@
 
 	<fileSets>
 		<fileSet>
-			<directory>${project.build.directory}/appassembleri/lib</directory>
+			<directory>${project.build.directory}/appassembler/lib</directory>
 			<outputDirectory>lib</outputDirectory>
 		</fileSet>
 

--- a/kieker-trace-diagnosis-release-engineering/assembly/bin-linux.xml
+++ b/kieker-trace-diagnosis-release-engineering/assembly/bin-linux.xml
@@ -12,7 +12,7 @@
 
 	<files>
 		<file>
-			<source>${project.build.directory}\appassembler\bin\start</source>
+			<source>${project.build.directory}/appassembler/bin/start</source>
 			<outputDirectory>bin</outputDirectory>
 		</file>
 	</files>

--- a/kieker-trace-diagnosis-release-engineering/assembly/bin-windows.xml
+++ b/kieker-trace-diagnosis-release-engineering/assembly/bin-windows.xml
@@ -12,7 +12,7 @@
 
 	<files>
 		<file>
-			<source>${project.build.directory}\appassembler\bin\start.bat</source>
+			<source>${project.build.directory}/appassembler/bin/start.bat</source>
 			<outputDirectory>bin</outputDirectory>
 		</file>
 	</files>


### PR DESCRIPTION
When executing the build in a Linux context, I noticed that files could not be found due to backslashes in the paths defined in some XML-Files. I fixed this in this PR. It should be tested in a Windows environment to make sure that this change did not break the build for Windows.